### PR TITLE
feat: add TTS provider abstraction for alternative backends

### DIFF
--- a/cmd/markloud/main.go
+++ b/cmd/markloud/main.go
@@ -22,6 +22,7 @@ func main() {
 	inputDir := flag.String("i", "", "Input directory containing markdown files")
 	outputDir := flag.String("o", "", "Output directory for audio files")
 	voice := flag.String("voice", getenv("OPENAI_TTS_VOICE", "alloy"), "TTS voice (alloy, echo, fable, onyx, nova, shimmer)")
+	provider := flag.String("provider", getenv("MARKLOUD_PROVIDER", "openai"), "TTS provider (openai, azure, cohere)")
 	overwrite := flag.Bool("overwrite", false, "Overwrite existing audio files")
 	showVersion := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
@@ -40,6 +41,7 @@ func main() {
 			InputDir:  *inputDir,
 			OutputDir: *outputDir,
 			Voice:     *voice,
+			Provider:  *provider,
 			Overwrite: *overwrite,
 		}
 	}

--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -15,6 +15,15 @@ import (
 	"time"
 )
 
+// Provider identifies the TTS backend.
+type Provider string
+
+const (
+	ProviderOpenAI Provider = "openai"
+	ProviderAzure  Provider = "azure"
+	ProviderCohere Provider = "cohere"
+)
+
 // Config holds inputs for a conversion run.
 type Config struct {
 	Root           string
@@ -27,6 +36,16 @@ type Config struct {
 	Instructions   string
 	APIKey         string
 	Pattern        string
+
+	// Provider selects which TTS backend to use.
+	Provider Provider
+
+	// Azure-specific config
+	AzureKey    string
+	AzureRegion string
+
+	// Cohere-specific config
+	CohereEndpoint string
 }
 
 // FileJob describes one markdown file to convert.
@@ -59,12 +78,46 @@ type TTSClient interface {
 
 type openAIClient struct {
 	httpClient *http.Client
+	endpoint   string
+}
+
+type azureClient struct {
+	httpClient *http.Client
+	endpoint   string
+	region     string
+}
+
+type cohereClient struct {
+	httpClient *http.Client
+	endpoint   string
 }
 
 var (
-	defaultHTTPClient           = &http.Client{Timeout: 90 * time.Second}
-	ttsClient         TTSClient = &openAIClient{httpClient: defaultHTTPClient}
+	defaultHTTPClient = &http.Client{Timeout: 90 * time.Second}
+	ttsClient         TTSClient // nil means use NewTTSClient(cfg)
 )
+
+// NewTTSClient creates a TTS client for the given provider based on the config.
+// If provider is empty, defaults to OpenAI.
+func NewTTSClient(cfg Config) TTSClient {
+	switch cfg.Provider {
+	case ProviderAzure:
+		endpoint := cfg.AzureRegion
+		if endpoint == "" {
+			endpoint = "eastus"
+		}
+		return &azureClient{httpClient: defaultHTTPClient, endpoint: endpoint}
+	case ProviderCohere:
+		endpoint := cfg.CohereEndpoint
+		if endpoint == "" {
+			endpoint = "https://api.cohere.ai/v1/audio/speech"
+		}
+		return &cohereClient{httpClient: defaultHTTPClient, endpoint: endpoint}
+	default:
+		// Default to OpenAI for backwards compatibility
+		return &openAIClient{httpClient: defaultHTTPClient, endpoint: "https://api.openai.com/v1/audio/speech"}
+	}
+}
 
 // SetTTSClient overrides the global TTS client (used in tests).
 func SetTTSClient(c TTSClient) {
@@ -242,6 +295,13 @@ func ProcessFile(ctx context.Context, job FileJob, cfg Config, progress func(cur
 		progress(0, totalChunks)
 	}
 	var buf bytes.Buffer
+
+	// Use the global ttsClient if set (e.g., by tests), otherwise create one based on config
+	client := ttsClient
+	if client == nil {
+		client = NewTTSClient(cfg)
+	}
+
 	for idx, chunk := range chunks {
 		if err := ctx.Err(); err != nil {
 			return JobResult{Status: JobFailed, Chunks: totalChunks, Err: err}
@@ -249,10 +309,10 @@ func ProcessFile(ctx context.Context, job FileJob, cfg Config, progress func(cur
 		if progress != nil {
 			progress(idx+1, totalChunks)
 		}
-		if ttsClient == nil {
+		if client == nil {
 			return JobResult{Status: JobFailed, Chunks: totalChunks, Err: errors.New("tts client not configured")}
 		}
-		chunkAudio, err := ttsClient.Synthesize(ctx, cfg, chunk)
+		chunkAudio, err := client.Synthesize(ctx, cfg, chunk)
 		if err != nil {
 			return JobResult{Status: JobFailed, Chunks: totalChunks, Err: err}
 		}
@@ -274,6 +334,9 @@ func (c *openAIClient) Synthesize(ctx context.Context, cfg Config, chunk string)
 	}
 	if c.httpClient == nil {
 		c.httpClient = defaultHTTPClient
+	}
+	if c.endpoint == "" {
+		c.endpoint = "https://api.openai.com/v1/audio/speech"
 	}
 
 	payload := map[string]any{
@@ -301,7 +364,105 @@ func (c *openAIClient) Synthesize(ctx context.Context, cfg Config, chunk string)
 		}
 
 		var buf bytes.Buffer
-		if err := doTTSRequest(ctx, c.httpClient, cfg.APIKey, body, &buf); err != nil {
+		if err := doTTSRequest(ctx, c.httpClient, c.endpoint, cfg.APIKey, body, &buf); err != nil {
+			lastErr = err
+			var apiErr *apiError
+			if errors.As(err, &apiErr) && apiErr.retryable {
+				continue
+			}
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, errors.New("unknown TTS error")
+}
+
+func (c *azureClient) Synthesize(ctx context.Context, cfg Config, chunk string) ([]byte, error) {
+	if c.region == "" {
+		c.region = "eastus"
+	}
+	if c.httpClient == nil {
+		c.httpClient = defaultHTTPClient
+	}
+
+	// Azure Cognitive Services TTS uses a different endpoint format
+	endpoint := fmt.Sprintf("https://%s.tts.speech.microsoft.com/cognitiveservices/v1", c.region)
+
+	payload := map[string]any{
+		"input":        chunk,
+		"voice":        cfg.Voice,
+		"format":       "audio-24khz-48kbitrate-mono-mp3",
+		"outputFormat": "audio-24khz-48kbitrate-mono-mp3",
+	}
+	if cfg.Speed > 0 && cfg.Speed != 1.0 {
+		payload["rate"] = fmt.Sprintf("%+d%%", int((cfg.Speed-1)*100))
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		if attempt > 1 {
+			time.Sleep(time.Duration(attempt*attempt) * 300 * time.Millisecond)
+		}
+
+		var buf bytes.Buffer
+		if err := doAzureTTSRequest(ctx, c.httpClient, endpoint, cfg.APIKey, body, &buf); err != nil {
+			lastErr = err
+			var apiErr *apiError
+			if errors.As(err, &apiErr) && apiErr.retryable {
+				continue
+			}
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, errors.New("unknown TTS error")
+}
+
+func (c *cohereClient) Synthesize(ctx context.Context, cfg Config, chunk string) ([]byte, error) {
+	if cfg.APIKey == "" {
+		return nil, errors.New("COHERE_API_KEY is missing")
+	}
+	if c.httpClient == nil {
+		c.httpClient = defaultHTTPClient
+	}
+	if c.endpoint == "" {
+		c.endpoint = "https://api.cohere.ai/v1/audio/speech"
+	}
+
+	payload := map[string]any{
+		"model":         cfg.Model,
+		"input":         chunk,
+		"voice":         cfg.Voice,
+		"output_format": cfg.ResponseFormat,
+	}
+	if cfg.Speed > 0 && cfg.Speed != 1.0 {
+		payload["speed"] = cfg.Speed
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		if attempt > 1 {
+			time.Sleep(time.Duration(attempt*attempt) * 300 * time.Millisecond)
+		}
+
+		var buf bytes.Buffer
+		if err := doTTSRequest(ctx, c.httpClient, c.endpoint, cfg.APIKey, body, &buf); err != nil {
 			lastErr = err
 			var apiErr *apiError
 			if errors.As(err, &apiErr) && apiErr.retryable {
@@ -327,13 +488,38 @@ func (e *apiError) Error() string {
 	return fmt.Sprintf("%s: %s", e.status, e.message)
 }
 
-func doTTSRequest(ctx context.Context, client *http.Client, apiKey string, body []byte, w io.Writer) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.openai.com/v1/audio/speech", bytes.NewReader(body))
+func doTTSRequest(ctx context.Context, client *http.Client, endpoint, apiKey string, body []byte, w io.Writer) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		retryable := resp.StatusCode == 429 || resp.StatusCode >= 500
+		return &apiError{status: resp.Status, message: strings.TrimSpace(string(snippet)), retryable: retryable}
+	}
+
+	_, err = io.Copy(w, resp.Body)
+	return err
+}
+
+func doAzureTTSRequest(ctx context.Context, client *http.Client, endpoint, apiKey string, body []byte, w io.Writer) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/ssml+xml")
+	req.Header.Set("Authorization", apiKey)
+	req.Header.Set("X-Microsoft-OutputFormat", "audio-24khz-48kbitrate-mono-mp3")
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -62,6 +62,7 @@ type CLIOptions struct {
 	InputDir  string
 	OutputDir string
 	Voice     string
+	Provider  string
 	Overwrite bool
 }
 
@@ -76,6 +77,7 @@ type model struct {
 	inputs     []textinput.Model
 	focusIndex int
 	overwrite  bool
+	provider   string
 	message    string
 	err        error
 
@@ -151,6 +153,7 @@ func initialModel(opts *CLIOptions, v VersionInfo) *model {
 		inputs:     inputs,
 		focusIndex: 0,
 		overwrite:  false,
+		provider:   envOr("MARKLOUD_PROVIDER", "openai"),
 		message:    "",
 		err:        nil,
 		ctx:        context.Background(),
@@ -167,6 +170,9 @@ func initialModel(opts *CLIOptions, v VersionInfo) *model {
 		m.inputs[1].SetValue(opts.OutputDir)
 		m.inputs[2].SetValue(opts.Voice)
 		m.overwrite = opts.Overwrite
+		if opts.Provider != "" {
+			m.provider = opts.Provider
+		}
 	}
 
 	return m
@@ -177,6 +183,41 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func nextProvider(current string) string {
+	switch current {
+	case "openai":
+		return "azure"
+	case "azure":
+		return "cohere"
+	case "cohere":
+		return "openai"
+	default:
+		return "openai"
+	}
+}
+
+func modelForProvider(provider string) string {
+	switch provider {
+	case "azure":
+		return "azure-tts"
+	case "cohere":
+		return "cohere-tts"
+	default:
+		return "tts-1-hd-1106"
+	}
+}
+
+func apiKeyForProvider(provider string) string {
+	switch provider {
+	case "azure":
+		return os.Getenv("AZURE_TTS_KEY")
+	case "cohere":
+		return os.Getenv("COHERE_API_KEY")
+	default:
+		return os.Getenv("OPENAI_API_KEY")
+	}
 }
 
 func (m *model) Init() tea.Cmd {
@@ -198,13 +239,25 @@ func (m *model) startConversionCmd() tea.Cmd {
 		Root:           root,
 		Out:            out,
 		Voice:          voice,
-		Model:          "tts-1-hd-1106",
+		Model:          modelForProvider(m.provider),
 		ResponseFormat: "aac",
 		Speed:          1.0,
 		Overwrite:      m.overwrite,
 		Instructions:   envOr("OPENAI_TTS_INSTRUCTIONS", "Speak clearly for podcast listening."),
-		APIKey:         strings.TrimSpace(os.Getenv("OPENAI_API_KEY")),
+		Provider:       convert.Provider(m.provider),
 		Pattern:        "*.md",
+	}
+
+	// Set provider-specific API key and config
+	switch cfg.Provider {
+	case convert.ProviderOpenAI:
+		cfg.APIKey = strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+	case convert.ProviderAzure:
+		cfg.APIKey = strings.TrimSpace(os.Getenv("AZURE_TTS_KEY"))
+		cfg.AzureRegion = strings.TrimSpace(envOr("AZURE_TTS_REGION", "eastus"))
+	case convert.ProviderCohere:
+		cfg.APIKey = strings.TrimSpace(os.Getenv("COHERE_API_KEY"))
+		cfg.CohereEndpoint = strings.TrimSpace(os.Getenv("COHERE_TTS_ENDPOINT"))
 	}
 
 	return prepareConversionCmd(cfg)
@@ -340,6 +393,9 @@ func (m *model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "o":
 			m.overwrite = !m.overwrite
 			return m, nil
+		case "p":
+			m.provider = nextProvider(m.provider)
+			return m, nil
 		case "enter":
 			return m.startConversion()
 		default:
@@ -423,13 +479,25 @@ func (m *model) startConversion() (tea.Model, tea.Cmd) {
 		Root:           root,
 		Out:            out,
 		Voice:          voice,
-		Model:          "tts-1-hd-1106",
+		Model:          modelForProvider(m.provider),
 		ResponseFormat: "aac",
 		Speed:          1.0,
 		Overwrite:      m.overwrite,
 		Instructions:   envOr("OPENAI_TTS_INSTRUCTIONS", "Speak clearly for podcast listening."),
-		APIKey:         strings.TrimSpace(os.Getenv("OPENAI_API_KEY")),
+		Provider:       convert.Provider(m.provider),
 		Pattern:        "*.md",
+	}
+
+	// Set provider-specific API key and config
+	switch cfg.Provider {
+	case convert.ProviderOpenAI:
+		cfg.APIKey = strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+	case convert.ProviderAzure:
+		cfg.APIKey = strings.TrimSpace(os.Getenv("AZURE_TTS_KEY"))
+		cfg.AzureRegion = strings.TrimSpace(envOr("AZURE_TTS_REGION", "eastus"))
+	case convert.ProviderCohere:
+		cfg.APIKey = strings.TrimSpace(os.Getenv("COHERE_API_KEY"))
+		cfg.CohereEndpoint = strings.TrimSpace(os.Getenv("COHERE_TTS_ENDPOINT"))
 	}
 
 	m.err = nil
@@ -442,7 +510,7 @@ func (m *model) startConversion() (tea.Model, tea.Cmd) {
 func prepareConversionCmd(cfg convert.Config) tea.Cmd {
 	return func() tea.Msg {
 		if cfg.APIKey == "" {
-			return prepareFailedMsg{errors.New("OPENAI_API_KEY is not set")}
+			return prepareFailedMsg{errors.New(apiKeyErrorForProvider(string(cfg.Provider)))}
 		}
 		info, err := os.Stat(cfg.Root)
 		if err != nil || !info.IsDir() {
@@ -456,6 +524,17 @@ func prepareConversionCmd(cfg convert.Config) tea.Cmd {
 			return prepareFailedMsg{fmt.Errorf("no markdown files matching %s", cfg.Pattern)}
 		}
 		return preparedMsg{cfg: cfg, jobs: jobs}
+	}
+}
+
+func apiKeyErrorForProvider(provider string) string {
+	switch provider {
+	case "azure":
+		return "AZURE_TTS_KEY is not set"
+	case "cohere":
+		return "COHERE_API_KEY is not set"
+	default:
+		return "OPENAI_API_KEY is not set"
 	}
 }
 
@@ -549,9 +628,15 @@ func (m *model) versionLabel() string {
 }
 
 func (m *model) viewConfig() string {
+	providerLabel := m.provider
+	if m.provider == "openai" {
+		providerLabel = providerLabel + " (default)"
+	}
+
 	rows := []string{
-		titleStyle.Render(fmt.Sprintf("%s ▸ Markdown → AAC (OpenAI)", m.versionLabel())),
-		fmt.Sprintf("%s %s", labelStyle.Render("API key:"), presentMissing(os.Getenv("OPENAI_API_KEY"))),
+		titleStyle.Render(fmt.Sprintf("%s ▸ Markdown → AAC", m.versionLabel())),
+		fmt.Sprintf("%s %s", labelStyle.Render("Provider [p]:"), emphStyle.Render(providerLabel)),
+		fmt.Sprintf("%s %s", labelStyle.Render("API key:"), presentMissing(apiKeyForProvider(m.provider))),
 		"",
 		fmt.Sprintf("%s\n%s", labelStyle.Render("Input directory"), m.inputs[0].View()),
 		fmt.Sprintf("%s\n%s", labelStyle.Render("Output directory"), m.inputs[1].View()),
@@ -566,7 +651,7 @@ func (m *model) viewConfig() string {
 		rows = append(rows, dimStyle.Render(m.message))
 	}
 
-	rows = append(rows, dimStyle.Render(m.versionLabel()+" · tab/shift+tab to move · enter to start · o to toggle overwrite · q to quit"))
+	rows = append(rows, dimStyle.Render(m.versionLabel()+" · tab/shift+tab to move · enter to start · o to toggle overwrite · p to change provider · q to quit"))
 
 	return boxStyle.Width(76).Render(strings.Join(rows, "\n"))
 }


### PR DESCRIPTION
## Summary
Add TTS provider abstraction to support multiple backends (OpenAI, Azure, Cohere).

- Define `Provider` type with `openai`, `azure`, and `cohere` variants
- Each provider has its own client implementation with custom endpoints
- Add `-provider` CLI flag (defaults to `MARKLOUD_PROVIDER` env var)
- Add provider selector `[p]` in TUI for cycling through providers
- Provider-specific config fields: `AzureKey`, `AzureRegion`, `CohereEndpoint`
- OpenAI remains the default for backwards compatibility

## Acceptance Criteria
- [x] TTSClient interface is generic enough for multiple providers
- [x] OpenAI remains the default (current behavior)
- [x] Provider selection is persisted in config
- [x] Each provider has its own model/endpoint configuration

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)